### PR TITLE
Disabled logic for expires token

### DIFF
--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -115,11 +115,14 @@ function checkToken (done) {
         'The access token provided is invalid.'));
     }
 
+   /* NOTE: disabled as token expires being disabled is not stopping this
+      The main library seems to have been updated heavily since we forked.
+      
     if (token.expires !== null &&
       (!token.expires || token.expires < new Date())) {
       return done(error('invalid_token',
         'The access token provided has expired.'));
-    }
+    } */
 
     // Expose params
     self.req.oauth = { bearerToken: token };


### PR DESCRIPTION
@johanbrook the Lookback fork seems to be quite behind now, so as this seems to be an issue and isn't required I have just commented out – are you ok with this?
